### PR TITLE
fix functionality of searchPast

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,13 @@
 {
     "configurations": [
         {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Python Debugger: Flask",
             "type": "debugpy",
             "request": "launch",

--- a/playlist_update.py
+++ b/playlist_update.py
@@ -55,7 +55,7 @@ def get_playlist_duration(playlist_link):
     playlist_ID = playlist_link.split('/')[-1].split('?')[0]
 
     # data, TOKEN, refresh_token, expires_at = get_spotify_json() #check out new spotify.json   
-    config_data = config_tools.config_data()
+    config_data = config_tools.config_data('setup.json')
     init_spotify_flag = config_data['init_spotify_flag']
 
     sp = refresh_sp(init_spotify_flag)
@@ -74,7 +74,7 @@ def get_playlist_duration(playlist_link):
 
     # Convert milliseconds to hours
     duration_hours = total_duration_ms / (1000 * 60 * 60)
-    
+    print(duration_hours)
     return duration_hours
 
 

--- a/playlist_update.py
+++ b/playlist_update.py
@@ -117,7 +117,7 @@ def cache_2_json(init_spotify_token_flag):
             with open("setup.json", "r") as jsonFile:
                 data = json.load(jsonFile)
 
-            data["use_init_spotify_token"] = False
+            data["init_spotify_flag"] = False
 
             with open("setup.json", "w") as jsonFile:
                 json.dump(data, jsonFile, indent=4)
@@ -273,3 +273,18 @@ def song_link_extract(msg):
     song = match.group(0) if match else None
     
     return song
+
+def get_track_name_and_artist(trackID):
+
+    config_data = config_tools.config_data('setup.json')
+    init_spotify_flag = config_data['init_spotify_flag']
+
+    sp = refresh_sp(init_spotify_flag)
+
+    now = int(time.time())#gets the current time
+
+    track = sp.track(trackID)
+    artists = track['artists']
+    # {track['artists']['name']
+
+    return f"{track['name']} - {artists[0]['name']}"

--- a/spotbot.py
+++ b/spotbot.py
@@ -60,7 +60,8 @@ async def on_ready():
 @bot.command()
 async def hlp(ctx):
     helpText = ("The commands for this bot go as follows: \n" + 
-        "[!]sLink (gives the user the link to the spotify playlist) \n" + 
+        "[!]sLink (gives the user the link to the spotify playlist that the channel is associated with) \n" + 
+        "[!]sLinkAll (gives the user the all of the links to the spotify playlists that spotbot is associated with) \n" + 
         "[!]grabPast (allows for the user to grab past songs sent in a chat, this can only be ran once) \n" +
         "[!]r (gives the user a random song from the playlist!) \n" +
         "[!]waves (generate Spotify's wave codes png image files.)\n")
@@ -80,8 +81,18 @@ async def hlp(ctx):
 async def sLink(ctx):
     config_data = config_tools.config_data(SECRET_DATABASE)
     playlist_channel = config_data['playlist_channel']
+    playlist_link = channel_tools.return_playlist_from_channel(sent_channel=ctx.channel.id, playlist_channel=playlist_channel)
+    #playlist_links = await channel_tools.return_playlists(playlist_channel=playlist_channel)
+    await ctx.reply(playlist_link)
+
+@bot.command()
+async def sLinkAll(ctx):
+    config_data = config_tools.config_data(SECRET_DATABASE)
+    playlist_channel = config_data['playlist_channel']
+    #playlist_link = channel_tools.return_playlist_from_channel(sent_channel=ctx.channel.id, playlist_channel=playlist_channel)
     playlist_links = await channel_tools.return_playlists(playlist_channel=playlist_channel)
     await ctx.reply(playlist_links)
+
 
 #a request command to give the user back a random song from the playlist 
 @bot.command()
@@ -486,10 +497,14 @@ async def on_message(msg):
         #     return True
     else:
         print(pgrm_signature + "Not valid Spotify channel: " + str(msg.channel.id) + " | spotbot looking at channels: " + str(channels))
+        await bot.process_commands(msg)
 
 
 @bot.command()
-async def waves(ctx, arg):
+async def waves(ctx, arg = None):
+    if(arg == None):
+        await ctx.channel.reply('User Must provide a spotify link argument for this command to work')
+        return
     for playlist in PLAYLIST_CHANNEL:
         # Command only functions within the global variable: discord_channel, specified in setup.json
         if ctx.channel.id == int(playlist['channel']):

--- a/spotbot.py
+++ b/spotbot.py
@@ -43,7 +43,7 @@ async def on_ready():
     #Lets programmer know that the bot has been activated
     print(pgrm_signature + 'SpotifyBot: ON')
     
-    if check_past_on_boot == True:
+    if str(check_past_on_boot).upper() == 'TRUE':
         for channel_item in config_data['playlist_channel']:
             channel = int(channel_item['channel'])
             channel_ctx = bot.get_channel(channel)
@@ -609,8 +609,8 @@ def dupCheck(msg, playlist_link):
                     (stripped, playlist_ID, getSender(msg), getTimestamp(msg), getMessageID(msg)))
         conn.commit()
         
-        print(pgrm_signature + 'String', songlink , 'Not Found')
-
+        print(pgrm_signature + 'NEW! | String', songlink , 'Not Found')
+        return False
     # Close the connection to the database
     conn.close()
 

--- a/supporting_scripts/channel_tools.py
+++ b/supporting_scripts/channel_tools.py
@@ -96,9 +96,9 @@ def emoji_list_match(list1, list2):
     else:
         return False
 
-async def addEmoji(msg, checkEmoji = "☑️"):
+async def addEmoji(msg, emoji = "☑️"):
     print(msg.content)
-    await msg.add_reaction (checkEmoji)
+    await msg.add_reaction (emoji)
 
 async def emojiCheck(msg):
     checkEmoji = "☑️"

--- a/supporting_scripts/config_tools.py
+++ b/supporting_scripts/config_tools.py
@@ -8,8 +8,6 @@ def config_data(file):
 
     setupf.close()
     return data
-
-
 #function to setup channel playlist relationships from json here
 def playlist_w_channel_setup(playlist_channel):
     pc_relationship = {}

--- a/supporting_scripts/config_tools.py
+++ b/supporting_scripts/config_tools.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import json
 import time, os
 
-def config_data(file):
+def config_data(file='setup.json'):
     with open(file, 'r') as setupf:
         data = json.load(setupf)
 


### PR DESCRIPTION
Fixes allow for token to once again be utlize the updated sendoff function. Fixes searchPast function and reguar spotbot usage

1. we overwrote some of my code with the pushes leaving some code to be yk non-existent, (which we do smaller pushes now so it should be fine
2. checks for loading .cache were not getting sent due to the setup.json file not having all of the flags (which we have the correct setup.json file now in #bot-code )
3. spotify.json was missing and there was no auto generating of the file (I manually made the file, we should ensure this blank file exists as well as .cache before the bot runs or else we are asking for slew of problems I did not fix this)
4. small check for true in json file to allow strings not just boolean litterals (solved by forcing everything to always be a string and uppercase